### PR TITLE
feat(navbar): create a navbar for mobile

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 import '@/styles/globals.css'
-import { Sidebar } from '@/components/Sidebar'
+import { MobileSidebar, Sidebar } from '@/components/Sidebar'
 
 export const metadata = {
   title: 'Loopy',
@@ -9,7 +9,10 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="flex w-full">
+    <div className="flex max-sm:flex-col w-full">
+      <div className="flex-1 sm:hidden w-full transition-200">
+        <MobileSidebar />
+      </div>
       <div className="flex-1 xl:max-w-xs max-sm:hidden w-full max-w-[80px] transition-200">
         <Sidebar />
       </div>

--- a/src/components/Sidebar/MobileSidebar.tsx
+++ b/src/components/Sidebar/MobileSidebar.tsx
@@ -52,24 +52,3 @@ export function MobileSidebar() {
     </div>
   )
 }
-
-/* <nav>
-<ul className="flex gap-2">
-  {Object.values(links).map((link) => (
-    <li key={link.label}>
-      <NavLink href={link.href}>
-        {link.icon}
-        <p>{link.label}</p>
-      </NavLink>
-    </li>
-  ))}
-</ul>
-</nav>
-<div className="text-sm flex gap-1">
-<NavLink href="#">
-  <p>Changelog</p>
-</NavLink>
-<NavLink href="#">
-  <p>Share Feedback</p>
-</NavLink>
-  </div> */

--- a/src/components/Sidebar/MobileSidebar.tsx
+++ b/src/components/Sidebar/MobileSidebar.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+import { UserIcon, HomeIcon, Bars3Icon, XMarkIcon } from '@heroicons/react/20/solid'
+import { NavLink } from './NavLink'
+
+const links = {
+  home: {
+    href: '/',
+    icon: <HomeIcon width={24} height={24} />,
+    label: 'Home',
+  },
+  user: {
+    href: '#',
+    icon: <UserIcon width={24} height={24} />,
+    label: 'User',
+  },
+}
+
+export function MobileSidebar() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="flex w-full flex-col gap-6 p-6 border-b border-base-6 bg-base-2">
+      <button className="self-end" onClick={() => setOpen(!open)}>
+        {open ? <XMarkIcon width={24} height={24} /> : <Bars3Icon width={24} height={24} />}
+      </button>
+      {open && (
+        <div>
+          <nav>
+            <ul className="flex flex-col gap-2">
+              {Object.values(links).map((link) => (
+                <li key={link.label} className="w-full">
+                  <NavLink href={link.href}>
+                    {link.icon}
+                    <p>{link.label}</p>
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
+          <div className="text-sm flex flex-col mt-2 gap-1 border-t border-base-6">
+            <NavLink href="#">
+              <p>Changelog</p>
+            </NavLink>
+            <NavLink href="#">
+              <p>Share Feedback</p>
+            </NavLink>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* <nav>
+<ul className="flex gap-2">
+  {Object.values(links).map((link) => (
+    <li key={link.label}>
+      <NavLink href={link.href}>
+        {link.icon}
+        <p>{link.label}</p>
+      </NavLink>
+    </li>
+  ))}
+</ul>
+</nav>
+<div className="text-sm flex gap-1">
+<NavLink href="#">
+  <p>Changelog</p>
+</NavLink>
+<NavLink href="#">
+  <p>Share Feedback</p>
+</NavLink>
+  </div> */

--- a/src/components/Sidebar/NavLink.tsx
+++ b/src/components/Sidebar/NavLink.tsx
@@ -1,0 +1,14 @@
+export function NavLink({
+  href,
+  children,
+}: {
+  href: string
+  // eslint-disable-next-line no-undef
+  children: JSX.Element[] | JSX.Element
+}) {
+  return (
+    <a className="flex items-center gap-3 hover:bg-base-4 p-2 rounded-lg" href={href}>
+      {children}
+    </a>
+  )
+}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,43 +1,51 @@
+import React from 'react'
 import { UserIcon, HomeIcon } from '@heroicons/react/20/solid'
+
+// eslint-disable-next-line no-undef
+
+const links = {
+  home: {
+    href: '/',
+    icon: <HomeIcon width={24} height={24} />,
+    label: 'Home',
+  },
+  user: {
+    href: '#',
+    icon: <UserIcon width={24} height={24} />,
+    label: 'User',
+  },
+}
+
+function NavLink({ href, children }: { href: string; children: JSX.Element[] | JSX.Element }) {
+  return (
+    <a className="flex items-center gap-3 hover:bg-base-4 p-2 rounded-lg" href={href}>
+      {children}
+    </a>
+  )
+}
 
 export function Sidebar() {
   return (
     <div className="flex h-screen w-full max-xl:items-center justify-between flex-col gap-6 p-6   border-r border-base-6 bg-base-2">
       <nav>
         <ul className="flex flex-col gap-2">
-          <li>
-            <a className="flex items-center gap-3 hover:bg-base-4 rounded-lg p-2" href="/">
-              <HomeIcon width={24} height={24} />
-              <p>Home</p>
-            </a>
-          </li>
-          <li>
-            <a className="flex items-center gap-3 hover:bg-base-4 rounded-lg p-2" href="/">
-              <UserIcon width={24} height={24} />
-              <p>User</p>
-            </a>
-          </li>
-          <li>
-            <a className="flex items-center gap-3 hover:bg-base-4 rounded-lg p-2" href="/">
-              <UserIcon width={24} height={24} />
-              <p>user</p>
-            </a>
-          </li>
-          <li>
-            <a className="flex items-center gap-3 hover:bg-base-4 rounded-lg p-2" href="/">
-              <UserIcon width={24} height={24} />
-              <p>User</p>
-            </a>
-          </li>
+          {Object.values(links).map((link) => (
+            <li key={link.label}>
+              <NavLink href={link.href}>
+                {link.icon}
+                <p>{link.label}</p>
+              </NavLink>
+            </li>
+          ))}
         </ul>
       </nav>
       <div className="text-sm flex flex-col gap-1">
-        <div className="flex items-center gap-3 hover:bg-base-4 p-2 rounded-lg">
+        <NavLink href="#">
           <p>Changelog</p>
-        </div>
-        <div className="flex items-center gap-3 hover:bg-base-4 p-2 rounded-lg">
+        </NavLink>
+        <NavLink href="#">
           <p>Share Feedback</p>
-        </div>
+        </NavLink>
       </div>
     </div>
   )

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { UserIcon, HomeIcon } from '@heroicons/react/20/solid'
-
-// eslint-disable-next-line no-undef
+import { NavLink } from './NavLink'
 
 const links = {
   home: {
@@ -14,14 +13,6 @@ const links = {
     icon: <UserIcon width={24} height={24} />,
     label: 'User',
   },
-}
-
-function NavLink({ href, children }: { href: string; children: JSX.Element[] | JSX.Element }) {
-  return (
-    <a className="flex items-center gap-3 hover:bg-base-4 p-2 rounded-lg" href={href}>
-      {children}
-    </a>
-  )
 }
 
 export function Sidebar() {

--- a/src/components/Sidebar/index.ts
+++ b/src/components/Sidebar/index.ts
@@ -1,1 +1,2 @@
 export { Sidebar } from './Sidebar'
+export { MobileSidebar } from './MobileSidebar'


### PR DESCRIPTION
This pull request relates to issue #3, which I was assigned for. This aims to create a proper navbar for mobile resolutions and also refactor some parts of the sidebar to be more modular and reusable.

- For the reviewers, I would just like to get your attention for potential format discrepancies between my config and project's.
- Also, I would also like to suggest the use of framer-motion for some animations inside the project. I'm particular nitty-pick with my own work, as even if it works, I'm not satisfied on how it feels for the end user.

Thanks! 